### PR TITLE
Add note on Fortran 2008 compiler requirement to the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,13 @@ Main features:
 * Lapack interface (and a few simple f90 wrappers like ``eigh``, ``inv``)
 * HDF5 interface
 
+Requirements
+------------
+
+The modules utils and ppm in ``utils.f90`` and ``ppm.f90`` use the
+``newunit`` option to ``open()``. This option is part of Fortran 2008 and
+requires at least gfortran 4.5 to compile.
+
 Contributors
 ------------
 


### PR DESCRIPTION
Gfortran 4.4 fails on utils.f90 and ppm.f90. As 4.4 is likely widespread (RHEL 6!), I've added a note on F2008 compilers to the README.
