### PR TITLE
Change project name in in CMake file to "fortranutils"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_SOURCE_DIR}/cmake/UserOverride.cmake)
 
 enable_language(Fortran)
 
-project(featom)
+project(fortranutils)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
The old name seemed to be leftover from another cmake file.
